### PR TITLE
Update GSM_MQTT.cpp

### DIFF
--- a/src/GSM_MQTT.cpp
+++ b/src/GSM_MQTT.cpp
@@ -876,7 +876,7 @@ void serialEvent()
           else if (ReceivedMessageType == PINGREQ)
           {
             MQTT.TCP_Flag = false;
-            MQTT.MQTT_flag = false;
+            MQTT.MQTT_Flag = false;
             MQTT.pingFlag = false;
             mySerial.println("Disconnecting");
             MQTT.sendATreply("AT+CIPSHUT\r\n", ".", 4000) ;


### PR DESCRIPTION
Fix: error: 'class GSM_MQTT' has no member named 'MQTT_flag'; did you mean 'MQTT_Flag'?
MQTT.MQTT_flag = false;
 updated the variable name to MQTT_Flag